### PR TITLE
Update documentation for 'az' command not found

### DIFF
--- a/docs-ref-conceptual/install-azure-cli.md
+++ b/docs-ref-conceptual/install-azure-cli.md
@@ -61,6 +61,10 @@ pip install --user azure-cli
 
 Run Azure CLI 2.0 from the command prompt with the 'az' command.
 
+
+> [!NOTE]
+> Sometimes the 'az' commands are added to a different file directory than where your default Python environment variable is pointing.  If the 'az' command is not found, add the following: ` C:\Users\X\AppData\Roaming\Python\Python36\Scripts` to your User Variables PATH, where `X` is your domain username. Restart your command prompt and try running 'az' again.
+
 ## Linux
 
 On Linux, you may need to install specific [prerequisites](#linux-prerequisites).


### PR DESCRIPTION
There is an error that is highlighted on the GitHub page, this page's comments, and one I have personally verified with the 'az' command installation into a different directory than where the default PATH variable points.