### PR TITLE
Updated query results to reflect correct order

### DIFF
--- a/docs-ref-conceptual/query-azure-cli.md
+++ b/docs-ref-conceptual/query-azure-cli.md
@@ -43,17 +43,17 @@ az vm list \
 ```
 
 ```
-Column1    Column2
----------  -----------
-DEMORG1    DemoVM010
-DEMORG1    demovm111
-DEMORG1    demovm211
-DEMORG1    demovm212
-DEMORG1    demovm213
-DEMORG1    demovm214
-DEMORG1    demovm222
-RGDEMO001  KBDemo001VM
-RGDEMO001  KBDemo020
+Column1     Column2
+---------   -----------
+DemoVM010   DEMORG1
+demovm111   DEMORG1
+demovm211   DEMORG1
+demovm212   DEMORG1
+demovm213   DEMORG1
+demovm214   DEMORG1
+demovm222   DEMORG1
+KBDemo001VM RGDEMO001
+KBDemo020   RGDEMO001
 ```
 
 In the previous example, you notice that the column headings are "Column1" and "Column2".  You can add friendly labels or names to the properties you select, as well.  In the following example, we added the labels "VMName" and "RGName" to the selected properties "name" and "resourceGroup".


### PR DESCRIPTION
Results of query did not reflect the correct order of the fields in the original query, thus the results would not have matched. Switched order of columns.