### PR TITLE
Fixes install location description for macOS & Linux

### DIFF
--- a/latest/docs-ref-conceptual/install-azure-cli.md
+++ b/latest/docs-ref-conceptual/install-azure-cli.md
@@ -502,7 +502,7 @@ If you used the script at https://aka.ms/InstallAzureCli to install the CLI, you
    ```
 
 > [!Note]
-> The default install location is `/Users/<username>`.
+> The default install location is `/Users/<username>` for macOS and `/home/<username>` for Linux.
 
 ## Report CLI issues and feedback
 


### PR DESCRIPTION
The default location for .bash_profile is /Users/<username>
in macOS, but in Linux /home/<username> is correct.