### PR TITLE
Added -it switch to Docker examples to get into the command line

### DIFF
--- a/docs-ref-conceptual/install-azure-cli.md
+++ b/docs-ref-conceptual/install-azure-cli.md
@@ -99,7 +99,7 @@ We maintain a Docker image preconfigured with the Azure CLI.
 Install the Azure CLI using `docker run`.
 
 ```bash
-docker run azuresdk/azure-cli-python:<version>
+docker run -it azuresdk/azure-cli-python:<version>
 ```
 
 See our [Docker tags](https://hub.docker.com/r/azuresdk/azure-cli-python/tags/) for available versions.
@@ -109,7 +109,7 @@ See our [Docker tags](https://hub.docker.com/r/azuresdk/azure-cli-python/tags/) 
 > you can use `-v ${HOME}:/root` to mount $HOME as `/root`.
 >
 > ```bash
-> docker run -v ${HOME}:/root azuresdk/azure-cli-python:<version>
+> docker run -it -v ${HOME}:/root azuresdk/azure-cli-python:<version>
 > ```
 
 The Docker image does not support the [`component` feature](/cli/azure/component).


### PR DESCRIPTION
As the purpose of the CLI is to use the command line I've added the `-it` parameter to the Docker example command lines.