### PR TITLE
Update install-azure-cli.md

### DIFF
--- a/docs-ref-conceptual/install-azure-cli.md
+++ b/docs-ref-conceptual/install-azure-cli.md
@@ -49,17 +49,17 @@ Get Azure CLI 2.0 on Windows using `pip`.
 
 1. Visit the Python site and [download Python](https://www.python.org/downloads/) for Windows.
    Be sure to install the Pip component when you install Python.
-   After the install completes, add Python to your PATH environment variable (the installer will prompt you).
+   When the installer prompts then make the selection to add Python to your PATH environment variable.
 
 2. Check your Python installation from a command prompt.
 
-   ```bash
+   ```cmd
    python --version
    ```
 
 3. Install Azure CLI 2.0 using `pip`.
 
-   ```bash
+   ```cmd
    pip install --user azure-cli
    ```
 


### PR DESCRIPTION
Tidying up Windows python install instructions - from bash to cmd, and altered the wording about PATH install as on Python 3.6.1 at least it asks at the beginning and not the end.