### PR TITLE
Update link to Bash installation instructions

### DIFF
--- a/docs-ref-conceptual/install-azure-cli.md
+++ b/docs-ref-conceptual/install-azure-cli.md
@@ -49,7 +49,7 @@ For information about the latest release, see the [release notes](release-notes-
 
 Azure CLI 2.0 supports Bash command syntax, making Bash on Windows a great way to use the CLI.
 
-1. If you don't have Bash on Windows, [install it](https://docs.microsoft.com/cli/azure/install-azure-cli).
+1. If you don't have Bash on Windows, [install it](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
 
 2. Open the Bash shell.
 


### PR DESCRIPTION
The current link is for this same page which is wrong. This is the link that I *_think_* is correct, but it hasn't been updated since December so its possible there is a newer one somewhere else. Either way it would be better than redirecting back to the same page :)