### PR TITLE
Add instructions for installing Python on Windows Bash

### DIFF
--- a/docs-ref-conceptual/install-azure-cli.md
+++ b/docs-ref-conceptual/install-azure-cli.md
@@ -53,6 +53,14 @@ Azure CLI 2.0 supports Bash command syntax, making Bash on Windows a great way t
 
 2. Open the Bash shell.
 
+2. Install Python and dependencies:
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install python
+   sudo apt-get install -y libssl-dev libffi-dev python-dev build-essential
+   ```
+
 2. Install Azure CLI 2.0 with one `curl` command.
 
    ```bash


### PR DESCRIPTION
Installing on Bash for Windows gives an error because Python is not installed. This change adds instructions to install Python and build essentials. Though I'm sure that in the past the install script installed these.