### PR TITLE
add event grid metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -94,6 +94,8 @@
           "docs-ref-autogen/dls.pycliyml": "datalake-store",
           "docs-ref-autogen/documentdb/**": "documentdb",
           "docs-ref-autogen/documentdb.pycliyml": "documentdb",
+          "docs-ref-autogen/eventgrid/**": "event-grid",
+          "docs-ref-autogen/eventgrid.yml": "event-grid",
           "docs-ref-autogen/feature/**": "azure-resource-manager",
           "docs-ref-autogen/feature.pycliyml": "azure-resource-manager",
           "docs-ref-autogen/functionapp/**": "functions",

--- a/titleMapping.json
+++ b/titleMapping.json
@@ -367,6 +367,38 @@
 		"TocTitle": "DocumentDB",
 		"PageTitle": "DocumentDB"
 	},
+	"az eventgrid": {
+		"TocTitle": "Event Grid",
+		"PageTitle": "Event Grid"
+	},
+	"az eventgrid event-subscription": {
+		"TocTitle": "Event subscription",
+		"PageTitle": "Event Grid event subscription"
+	},
+	"az eventgrid resource": {
+		"TocTitle": "Resource",
+		"PageTitle": "Event Grid resource"
+	},
+	"az eventgrid resource event-subscription": {
+		"TocTitle": "Event subscription",
+		"PageTitle": "Event Grid resource event subscription"
+	},
+	"az eventgrid topic": {
+		"TocTitle": "Topic",
+		"PageTitle": "Event Grid topic"
+	},
+	"az eventgrid topic event-subscription": {
+		"TocTitle": "Event subscription",
+		"PageTitle": "Event Grid topic event subscription"
+	},
+	"az eventgrid topic key": {
+		"TocTitle": "Key",
+		"PageTitle": "Event Grid topic key"
+	},
+	"az eventgrid topic-type": {
+		"TocTitle": "Topic type",
+		"PageTitle": "Event Grid topic type"
+	},
 	"az feature": {
 		"TocTitle": "Resource provider features",
 		"PageTitle": "Resource provider features"


### PR DESCRIPTION
I am trying to add Event Grid CLI commands to the published docs. The product team has placed the source code in command-modules, _help.py in the module, and added mapping. Is this the last step to complete CLI onboarding? 