### PR TITLE
Remove password from command line

### DIFF
--- a/latest/docs-ref-conceptual/authenticate-azure-cli.md
+++ b/latest/docs-ref-conceptual/authenticate-azure-cli.md
@@ -36,7 +36,7 @@ Provide your credentials on the command line.
 > This approach doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled.
 
 ```azurecli-interactive
-az login -u <username> -p <password>
+az login -u <username> 
 ```
 
 ## Logging in with a service principal


### PR DESCRIPTION
If we put the password on the command line, it's stored in the shell history. Removed the -p. The Azure CLI prompts for the password. User enters and no security risk with the history.