### PR TITLE
fix grammatical issues and single installer

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-macos.md
+++ b/docs-ref-conceptual/install-azure-cli-macos.md
@@ -15,7 +15,7 @@ ms.service: multiple
 
 # Install Azure CLI 2.0 on macOS
 
-For the macOS platform, you can install the Azure CLI either through the [homebrew package manager](http://brew.sh). Homebrew makes it easy to keep your
+For the macOS platform, you can install the Azure CLI with [homebrew package manager](http://brew.sh). Homebrew makes it easy to keep your
 installation of the CLI update to date. The CLI package has been tested on macOS versions 10.9 and later.
 
 ## Install


### PR DESCRIPTION
Not sure what "either" applies to as only Homebrew is now listed.

Advise if the script on demand is no longer supported . ie.
```
curl -L https://aka.ms/InstallAzureCli | bash
```

While that script does work, it's no longer clearly visible on the macOS install guide. So, is Homebrew the only way supported in the future? Please say "NO" - many of us are not full Brew fans.