### PR TITLE
Remove legacy configuration for generate pdf

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -1,6 +1,5 @@
 {
   "build_entry_point": "docs",
-  "need_generate_pdf": true,
   "docsets_to_publish": [
     {
       "docset_name": "azure-cli-docs",


### PR DESCRIPTION
As title. need_generate_pdf is retired and we shouldn't use that.