### PR TITLE
Fix spelling typo in titlemapping.json

### DIFF
--- a/titleMapping.json
+++ b/titleMapping.json
@@ -960,8 +960,8 @@
 		"PageTitle": "Storage container policies"
 	},
 	"az storage cors": {
-		"TocTitle": "Cross-origin resorce sharing",
-		"PageTitle": "Cross-origin resorce sharing"
+		"TocTitle": "Cross-origin resource sharing",
+		"PageTitle": "Cross-origin resource sharing"
 	},
 	"az storage directory": {
 		"TocTitle": "Directories",


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-cli/issues/7494
Fixes: https://github.com/Azure/azure-cli/issues/7116