### PR TITLE
Update guidance for "IPC connect call failed" scenario

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-apt.md
+++ b/docs-ref-conceptual/install-azure-cli-apt.md
@@ -96,7 +96,7 @@ gpg: connecting dirmngr at '/tmp/apt-key-gpghome.nMumTfhiHO/S.dirmngr' failed: I
 gpg: keyserver receive failed: No dirmngr
 ```
 
-If that occurs, the following workaround should allow you to add the appropriate key to continue installation
+If that occurs, the following workaround should allow you to add the appropriate key to continue installation:
 
 ```bash
 curl -sL "http://packages.microsoft.com/keys/microsoft.asc" | sudo apt-key --keyring /etc/apt/trusted.gpg.d/Microsoft.gpg add

--- a/docs-ref-conceptual/install-azure-cli-apt.md
+++ b/docs-ref-conceptual/install-azure-cli-apt.md
@@ -87,6 +87,21 @@ The error is due to a missing component required by `apt-key`. You can resolve i
 sudo apt-get install dirmngr
 ```
 
+### apt-key fails with "IPC connect call failed" message prior to "No dirmngr" message
+
+Due to [a previous issue in WSL](https://github.com/Microsoft/WSL/issues/3286), you may experience a variation of the following error:
+
+```output
+gpg: connecting dirmngr at '/tmp/apt-key-gpghome.nMumTfhiHO/S.dirmngr' failed: IPC connect call failed
+gpg: keyserver receive failed: No dirmngr
+```
+
+If that occurs, the following workaround should allow you to add the appropriate key to continue installation
+
+```bash
+curl -sL "http://packages.microsoft.com/keys/microsoft.asc" | sudo apt-key --keyring /etc/apt/trusted.gpg.d/Microsoft.gpg add
+```
+
 ### apt-key hangs
 
 When behind a firewall blocking outgoing connections to port 11371, the `apt-key` command might hang indefinitely.


### PR DESCRIPTION
When following this guide, I received an error message while attempting to add the key in order to install `azure-cli`.

```
gpg: connecting dirmngr at '/tmp/apt-key-gpghome.nMumTfhiHO/S.dirmngr' failed: IPC connect call failed
gpg: keyserver receive failed: No dirmngr
```

Upon further examination, it appears to be an issue with WSL that has a workaround: https://github.com/Microsoft/WSL/issues/3286

(I'm behind on Windows feature updates & WSL due to other unfortunate issues during upgrade).

This PR attempts to document the workaround here so that others will have it at the ready. Happy to re-format, update working, etc. as requested.

When applied, this worked for me and allowed me to continue the rest of the installation.